### PR TITLE
add `name` field to app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,5 @@
 kind: wasmer.io/App.v0
+name: wordpress # this can be overwritten in autobuild with the `--name` flag
 package: .
 capabilities:
   database:

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,4 @@
 kind: wasmer.io/App.v0
-name: wordpress # this can be overwritten in autobuild with the `--name` flag
 package: .
 capabilities:
   database:

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,6 +1,4 @@
 [package]
-name = "wasmer/wordpress"
-version = "0.0.110"
 entrypoint = "run"
 
 [dependencies]


### PR DESCRIPTION
this is because the name field is currently required by the wasmer-config schema.